### PR TITLE
Remove references to FTalkLine external class

### DIFF
--- a/DialogueBox.cpp
+++ b/DialogueBox.cpp
@@ -35,7 +35,7 @@ UDialogueBox::UDialogueBox(const FObjectInitializer& ObjectInitializer)
 	bHasFinishedPlaying = true;
 }
 
-void UDialogueBox::PlayLine(const FTalkLine& InLine)
+void UDialogueBox::PlayLine(const FText& InLine)
 {
 	check(GetWorld());
 
@@ -50,7 +50,7 @@ void UDialogueBox::PlayLine(const FTalkLine& InLine)
 	Segments.Empty();
 	CachedSegmentText.Empty();
 
-	if (CurrentLine.Text.IsEmpty())
+	if (CurrentLine.IsEmpty())
 	{
 		if (IsValid(LineText))
 		{
@@ -144,7 +144,7 @@ void UDialogueBox::CalculateWrappedString()
 		const FVector2D TextBoxSize = TextBoxGeometry.GetLocalSize();
 
 		Layout->SetWrappingWidth(TextBoxSize.X);
-		Marshaller->SetText(CurrentLine.Text.ToString(), *Layout.Get());
+		Marshaller->SetText(CurrentLine.ToString(), *Layout.Get());
 		Layout->UpdateIfNeeded();
 
 		bool bHasWrittenText = false;
@@ -192,7 +192,7 @@ void UDialogueBox::CalculateWrappedString()
 	}
 	else
 	{
-		Segments.Add(FDialogueTextSegment{CurrentLine.Text.ToString()});
+		Segments.Add(FDialogueTextSegment{CurrentLine.ToString()});
 		MaxLetterIndex = Segments[0].Text.Len();
 	}
 }

--- a/DialogueBox.h
+++ b/DialogueBox.h
@@ -5,8 +5,6 @@
 #include "CoreMinimal.h"
 #include "Blueprint/UserWidget.h"
 #include "Components/RichTextBlock.h"
-#include "Components/TextBlock.h"
-#include "Flame/Talk/TalkTypes.h"
 #include "Framework/Text/RichTextLayoutMarshaller.h"
 #include "Framework/Text/SlateTextLayout.h"
 #include "DialogueBox.generated.h"
@@ -65,10 +63,10 @@ public:
 	float EndHoldTime = 0.15f;
 
 	UFUNCTION(BlueprintCallable, Category = "Dialogue Box")
-	void PlayLine(const FTalkLine& InLine);
+	void PlayLine(const FText& InLine);
 
 	UFUNCTION(BlueprintCallable, Category = "Dialogue Box")
-	void GetCurrentLine(FTalkLine& OutLine) const { OutLine = CurrentLine; }
+	void GetCurrentLine(FText& OutLine) const { OutLine = CurrentLine; }
 
 	UFUNCTION(BlueprintCallable, Category = "Dialogue Box")
 	bool HasFinishedPlayingLine() const { return bHasFinishedPlaying; }
@@ -90,7 +88,7 @@ private:
 	FString CalculateSegments();
 
 	UPROPERTY()
-	FTalkLine CurrentLine;
+	FText CurrentLine;
 
 	TArray<FDialogueTextSegment> Segments;
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ you want.
 * Text wrapping is only calculated a single time when the first character is played. If the widget is resized for any reason, text will
   not respect the new boundaries. This should be simple to solve, I just haven't done it yet.
 * There may be some hidden i18n issues due to all the conversions between `FString`/`FText` and string indexing.
-* Some types (such as `FTalkLine`) are from my own dialogue system. It should be trivial to swap them out.
 * This has been tested with UE5.0EA, though it should work fine with earlier/later versions.
 * The current implementation was quickly thrown together (see: hacky) and somewhat unoptimized. Some data is duplicated more than it needs
   to be, and "segment" calculation is a bit more complex than I'd like.


### PR DESCRIPTION
These changes were needed for the compilation to succeed. 

P.S. Thanks for another great repo! It's been working like a charm.