### PR TITLE
Alternate approach - custom decorator/run

### DIFF
--- a/DialogueBox.cpp
+++ b/DialogueBox.cpp
@@ -149,8 +149,6 @@ private:
 	const int32* CurrentSegmentIndex;
 };
 
-
-
 TSharedRef<SWidget> UDialogueTextBlock::RebuildWidget()
 {
 	// Copied from URichTextBlock::RebuildWidget
@@ -163,6 +161,7 @@ TSharedRef<SWidget> UDialogueTextBlock::RebuildWidget()
 	TSharedRef<FRichTextLayoutMarshaller> Marshaller = FRichTextLayoutMarshaller::Create(TextParser, CreateMarkupWriter(), CreatedDecorators, StyleInstance.Get());
 	if (Segments && CurrentSegmentIndex)
 	{
+		// add custom decorator to intercept partially typed segments
 		Marshaller->AppendInlineDecorator(MakeShared<FPartialDialogueDecorator>(Segments, CurrentSegmentIndex));
 	}
 

--- a/DialogueBox.cpp
+++ b/DialogueBox.cpp
@@ -167,7 +167,7 @@ TSharedRef<SWidget> UDialogueTextBlock::RebuildWidget()
 
 	MyRichTextBlock =
 		SNew(SRichTextBlock)
-		.TextStyle(bOverrideDefaultStyle ? &DefaultTextStyleOverride : &DefaultTextStyle)
+		.TextStyle(bOverrideDefaultStyle ? &GetDefaultTextStyleOverride() : &DefaultTextStyle)
 		.Marshaller(Marshaller);
 
 	return MyRichTextBlock.ToSharedRef();

--- a/DialogueBox.cpp
+++ b/DialogueBox.cpp
@@ -151,15 +151,11 @@ private:
 
 void UDialogueTextBlock::SetTextPartiallyTyped(const FText& InText, const FText& InFinalText)
 {
-	ASSERT(!InText.IdenticalTo(InFinalText));
+	Super::SetText(InText);
+
 	if (SDialogueTextBlock* dialogueTextBlock = static_cast<SDialogueTextBlock*>(MyRichTextBlock.Get()))
 	{
-		Text = FText::GetEmpty();
 		dialogueTextBlock->SetText(dialogueTextBlock->MakeTextAttribute(InText, InFinalText));
-	}
-	else
-	{
-		Super::SetText(InText);
 	}
 }
 

--- a/DialogueBox.cpp
+++ b/DialogueBox.cpp
@@ -149,10 +149,12 @@ private:
 	const int32* CurrentSegmentIndex;
 };
 
-void UDialogueTextBlock::SetText(const FText& InText, const FText& InFinalText)
+void UDialogueTextBlock::SetTextPartiallyTyped(const FText& InText, const FText& InFinalText)
 {
+	ASSERT(!InText.IdenticalTo(InFinalText));
 	if (SDialogueTextBlock* dialogueTextBlock = static_cast<SDialogueTextBlock*>(MyRichTextBlock.Get()))
 	{
+		Text = FText::GetEmpty();
 		dialogueTextBlock->SetText(dialogueTextBlock->MakeTextAttribute(InText, InFinalText));
 	}
 	else
@@ -161,7 +163,7 @@ void UDialogueTextBlock::SetText(const FText& InText, const FText& InFinalText)
 	}
 }
 
-void UDialogueTextBlock::SetText(const FText& InText)
+void UDialogueTextBlock::SetTextFullyTyped(const FText& InText)
 {
 	Super::SetText(InText);
 }
@@ -214,7 +216,7 @@ void UDialogueBox::PlayLine(const FText& InLine)
 	{
 		if (IsValid(LineText))
 		{
-			LineText->SetText(FText::GetEmpty(), FText::GetEmpty());
+			LineText->SetTextFullyTyped(FText::GetEmpty());
 		}
 
 		bHasFinishedPlaying = true;
@@ -226,7 +228,7 @@ void UDialogueBox::PlayLine(const FText& InLine)
 	{
 		if (IsValid(LineText))
 		{
-			LineText->SetText(FText::GetEmpty(), CurrentLine);
+			LineText->SetTextPartiallyTyped(FText::GetEmpty(), CurrentLine);
 		}
 
 		bHasFinishedPlaying = false;
@@ -248,7 +250,7 @@ void UDialogueBox::SkipToLineEnd()
 	CurrentLetterIndex = MaxLetterIndex - 1;
 	if (IsValid(LineText))
 	{
-		LineText->SetText(FText::FromString(CalculateSegments()), CurrentLine);
+		LineText->SetTextFullyTyped(CurrentLine);
 	}
 
 	bHasFinishedPlaying = true;
@@ -276,7 +278,7 @@ void UDialogueBox::PlayNextLetter()
 	{
 		if (IsValid(LineText))
 		{
-			LineText->SetText(FText::FromString(WrappedString), CurrentLine);
+			LineText->SetTextPartiallyTyped(FText::FromString(WrappedString), CurrentLine);
 		}
 
 		OnPlayLetter();
@@ -286,7 +288,7 @@ void UDialogueBox::PlayNextLetter()
 	{
 		if (IsValid(LineText))
 		{
-			LineText->SetText(FText::FromString(CalculateSegments()), CurrentLine);
+			LineText->SetTextFullyTyped(CurrentLine);
 		}
 
 		FTimerManager& TimerManager = GetWorld()->GetTimerManager();

--- a/DialogueBox.cpp
+++ b/DialogueBox.cpp
@@ -6,6 +6,145 @@
 #include "Widgets/Text/SRichTextBlock.h"
 #include "TimerManager.h"
 
+#include <Framework/Text/SlateTextRun.h>
+#include <Framework/Text/RichTextMarkupProcessing.h>
+#include <Framework/Text/ShapedTextCache.h>
+
+class FDialogueBoxTextRun : public FSlateTextRun
+{
+public:
+	FVector2D MeasureInternal( int32 BeginIndex, int32 EndIndex, float Scale, const FRunTextContext& TextContext, const FString& InText ) const
+	{
+		const FVector2D ShadowOffsetToApply((EndIndex == Range.EndIndex) ? FMath::Abs(Style.ShadowOffset.X * Scale) : 0.0f, FMath::Abs(Style.ShadowOffset.Y * Scale));
+
+		// Offset the measured shaped text by the outline since the outline was not factored into the size of the text
+		// Need to add the outline offsetting to the beginning and the end because it surrounds both sides.
+		const float ScaledOutlineSize = Style.Font.OutlineSettings.OutlineSize * Scale;
+		const FVector2D OutlineSizeToApply((BeginIndex == Range.BeginIndex ? ScaledOutlineSize : 0) + (EndIndex == Range.EndIndex ? ScaledOutlineSize : 0), ScaledOutlineSize);
+
+		if (EndIndex - BeginIndex == 0)
+		{
+			return FVector2D(0, GetMaxHeight(Scale)) + ShadowOffsetToApply + OutlineSizeToApply;
+		}
+
+		// Use the full text range (rather than the run range) so that text that spans runs will still be shaped correctly
+		return ShapedTextCacheUtil::MeasureShapedText(TextContext.ShapedTextCache, FCachedShapedTextKey(FTextRange(0, InText.Len()), Scale, TextContext, Style.Font), FTextRange(BeginIndex, EndIndex), *InText) + ShadowOffsetToApply + OutlineSizeToApply;
+	}
+
+	FVector2D Measure(int32 StartIndex, int32 EndIndex, float Scale, const FRunTextContext& TextContext) const override
+	{
+		if (EndIndex != Range.EndIndex)
+		{
+			return FSlateTextRun::Measure(StartIndex, EndIndex, Scale, TextContext);
+		}
+
+		int32 partialContent = Range.Len();
+		check(partialContent >= 0);
+
+		FString futureContent;
+		if (!Segment.RunInfo.ContentRange.IsEmpty())
+		{
+			// with tags
+			futureContent = Segment.Text.Mid(Segment.RunInfo.ContentRange.BeginIndex - Segment.RunInfo.OriginalRange.BeginIndex + partialContent, Segment.RunInfo.ContentRange.Len() - partialContent);
+		}
+		else
+		{
+			// no tags
+			futureContent = Segment.Text.Mid(partialContent, Segment.RunInfo.OriginalRange.Len() - partialContent);
+		}
+		for (int32 i = 0; i < futureContent.Len(); ++i)
+		{
+			TCHAR futureChar = futureContent[i];
+			if (FText::IsWhitespace(futureChar))
+			{
+				futureContent.LeftInline(i);
+				break;
+			}
+		}
+
+		FString combinedContent = *Text + futureContent;
+		return MeasureInternal(StartIndex, combinedContent.Len(), Scale, TextContext, combinedContent);
+	}
+
+	FDialogueBoxTextRun(const FRunInfo& InRunInfo, const TSharedRef< const FString >& InText, const FTextBlockStyle& InStyle, const FDialogueTextSegment& Segment)
+		:
+		FSlateTextRun(InRunInfo, InText, InStyle),
+		Segment(Segment)
+	{
+	}
+
+	FDialogueBoxTextRun(const FRunInfo& InRunInfo, const TSharedRef< const FString >& InText, const FTextBlockStyle& InStyle, const FTextRange& InRange, const FDialogueTextSegment& Segment)
+		:
+		FSlateTextRun(InRunInfo, InText, InStyle, InRange),
+		Segment(Segment)
+	{
+	}
+
+private:
+	const FDialogueTextSegment& Segment;
+};
+
+class FDialogueBoxTextDecorator : public ITextDecorator
+{
+public:
+	FDialogueBoxTextDecorator(const TArray<FDialogueTextSegment>* Segments, const int32* CurrentSegmentIndex)
+		:
+		Segments(Segments),
+		CurrentSegmentIndex(CurrentSegmentIndex)
+	{
+	}
+
+	bool Supports(const FTextRunParseResults& RunInfo, const FString& Text) const override
+	{
+		// no segments have been calculated yet
+		if (*CurrentSegmentIndex >= Segments->Num())
+		{
+			return false;
+		}
+
+		// does this run relate to the segment which is still in-flight?
+		const FDialogueTextSegment& segment = (*Segments)[*CurrentSegmentIndex];
+		const FTextRange& segmentRange = !RunInfo.ContentRange.IsEmpty() ? segment.RunInfo.ContentRange : segment.RunInfo.OriginalRange;
+		const FTextRange& runRange = !RunInfo.ContentRange.IsEmpty() ? RunInfo.ContentRange : RunInfo.OriginalRange;
+		auto intersected = runRange.Intersect(segmentRange);
+		return !intersected.IsEmpty() && segmentRange != intersected;
+	}
+
+	TSharedRef<ISlateRun> Create(const TSharedRef<class FTextLayout>& TextLayout, const FTextRunParseResults& InRunInfo, const FString& ProcessedString, const TSharedRef<FString>& InOutModelText, const ISlateStyle* InStyle) override
+	{
+		FRunInfo RunInfo(InRunInfo.Name);
+		for (const TPair<FString, FTextRange>& Pair : InRunInfo.MetaData)
+		{
+			int32 Length = FMath::Max(0, Pair.Value.EndIndex - Pair.Value.BeginIndex);
+			RunInfo.MetaData.Add(Pair.Key, ProcessedString.Mid(Pair.Value.BeginIndex, Length));
+		}
+
+		const FTextBlockStyle* TextBlockStyle;
+		FTextRange ModelRange;
+		ModelRange.BeginIndex = InOutModelText->Len();
+		if (!(InRunInfo.Name.IsEmpty()) && InStyle->HasWidgetStyle< FTextBlockStyle >(FName(*InRunInfo.Name)))
+		{
+			*InOutModelText += ProcessedString.Mid(InRunInfo.ContentRange.BeginIndex, InRunInfo.ContentRange.Len());
+			TextBlockStyle = &(InStyle->GetWidgetStyle< FTextBlockStyle >(FName(*InRunInfo.Name)));
+		}
+		else
+		{
+			*InOutModelText += ProcessedString.Mid(InRunInfo.OriginalRange.BeginIndex, InRunInfo.OriginalRange.Len());
+			TextBlockStyle = &static_cast<FSlateTextLayout&>(*TextLayout).GetDefaultTextStyle();
+		}
+		ModelRange.EndIndex = InOutModelText->Len();
+
+		const FDialogueTextSegment& Segment = (*Segments)[*CurrentSegmentIndex];
+		return MakeShared<FDialogueBoxTextRun>(RunInfo, InOutModelText, *TextBlockStyle, ModelRange, Segment);
+	}
+
+private:
+	const TArray<FDialogueTextSegment>* Segments;
+	const int32* CurrentSegmentIndex;
+};
+
+
+
 TSharedRef<SWidget> UDialogueTextBlock::RebuildWidget()
 {
 	// Copied from URichTextBlock::RebuildWidget
@@ -14,18 +153,17 @@ TSharedRef<SWidget> UDialogueTextBlock::RebuildWidget()
 	TArray< TSharedRef< class ITextDecorator > > CreatedDecorators;
 	CreateDecorators(CreatedDecorators);
 
-	TextMarshaller = FRichTextLayoutMarshaller::Create(CreateMarkupParser(), CreateMarkupWriter(), CreatedDecorators, StyleInstance.Get());
+	TextParser = CreateMarkupParser();
+	TSharedRef<FRichTextLayoutMarshaller> Marshaller = FRichTextLayoutMarshaller::Create(TextParser, CreateMarkupWriter(), CreatedDecorators, StyleInstance.Get());
+	if (Segments && CurrentSegmentIndex)
+	{
+		Marshaller->AppendInlineDecorator(MakeShared<FDialogueBoxTextDecorator>(Segments, CurrentSegmentIndex));
+	}
 
 	MyRichTextBlock =
 		SNew(SRichTextBlock)
 		.TextStyle(bOverrideDefaultStyle ? &DefaultTextStyleOverride : &DefaultTextStyle)
-		.Marshaller(TextMarshaller)
-		.CreateSlateTextLayout(
-			FCreateSlateTextLayout::CreateWeakLambda(this, [this] (SWidget* InOwner, const FTextBlockStyle& InDefaultTextStyle) mutable
-			{
-				TextLayout = FSlateTextLayout::Create(InOwner, InDefaultTextStyle);
-				return StaticCastSharedPtr<FSlateTextLayout>(TextLayout).ToSharedRef();
-			}));
+		.Marshaller(Marshaller);
 
 	return MyRichTextBlock.ToSharedRef();
 }
@@ -45,7 +183,6 @@ void UDialogueBox::PlayLine(const FText& InLine)
 
 	CurrentLine = InLine;
 	CurrentLetterIndex = 0;
-	CachedLetterIndex = 0;
 	CurrentSegmentIndex = 0;
 	MaxLetterIndex = 0;
 	Segments.Empty();
@@ -96,6 +233,13 @@ void UDialogueBox::SkipToLineEnd()
 	OnLineFinishedPlaying();
 }
 
+void UDialogueBox::NativeOnInitialized()
+{
+	Super::NativeOnInitialized();
+
+	LineText->ConfigureFromParent(&Segments, &CurrentSegmentIndex);
+}
+
 void UDialogueBox::PlayNextLetter()
 {
 	if (Segments.IsEmpty())
@@ -133,129 +277,83 @@ void UDialogueBox::PlayNextLetter()
 	}
 }
 
-// TODO: Need to recalculate this + CalculateSegments when the text box gets resized.
 void UDialogueBox::CalculateWrappedString()
 {
-	if (IsValid(LineText) && LineText->GetTextLayout().IsValid())
+	if (IsValid(LineText) && LineText->GetTextParser().IsValid())
 	{
-		TSharedPtr<FSlateTextLayout> Layout = LineText->GetTextLayout();
-		TSharedPtr<FRichTextLayoutMarshaller> Marshaller = LineText->GetTextMarshaller();
+		TSharedPtr<IRichTextMarkupParser> Parser = LineText->GetTextParser();
 
-		const FGeometry& TextBoxGeometry = LineText->GetCachedGeometry();
-		const FVector2D TextBoxSize = TextBoxGeometry.GetLocalSize();
-
-		Layout->SetWrappingWidth(TextBoxSize.X);
-		Marshaller->SetText(CurrentLine.ToString(), *Layout.Get());
-		Layout->UpdateIfNeeded();
-
-		bool bHasWrittenText = false;
-		for (const FTextLayout::FLineView& View: Layout->GetLineViews())
+		TArray<FTextLineParseResults> Lines;
+		FString ProcessedString;
+		Parser->Process(Lines, CurrentLine.ToString(), ProcessedString);
+		for (int32 LineIdx = 0; LineIdx < Lines.Num(); ++LineIdx)
 		{
-			const FTextLayout::FLineModel& Model = Layout->GetLineModels()[View.ModelIndex];
-
-			for (TSharedRef<ILayoutBlock> Block : View.Blocks)
+			const FTextLineParseResults& Line = Lines[LineIdx];
+			for (const FTextRunParseResults& Run : Line.Runs)
 			{
-				TSharedRef<IRun> Run = Block->GetRun();
-
-				FDialogueTextSegment Segment;
-				Run->AppendTextTo(Segment.Text, Block->GetTextRange());
-
-				// HACK: For some reason image decorators (and possibly other decorators that don't
-				// have actual text inside them) result in the run containing a zero width space instead of
-				// nothing. This messes up our checks for whether the text is empty or not, which doesn't
-				// have an effect on image decorators but might cause issues for other custom ones.
-				if (Segment.Text.Len() == 1 && Segment.Text[0] == 0x200B)
-				{
-					Segment.Text.Empty();
-				}
-
-				Segment.RunInfo = Run->GetRunInfo();
-				Segments.Add(Segment);
-
-				// A segment with a named run should still take up time for the typewriter effect.
-				MaxLetterIndex += FMath::Max(Segment.Text.Len(), Segment.RunInfo.Name.IsEmpty() ? 0 : 1);
-
-				if (!Segment.Text.IsEmpty() || !Segment.RunInfo.Name.IsEmpty())
-				{
-					bHasWrittenText = true;
-				}
+				Segments.Emplace(
+					FDialogueTextSegment
+					{
+						ProcessedString.Mid(Run.OriginalRange.BeginIndex, Run.OriginalRange.Len()),
+						Run
+					});
 			}
 
-			if (bHasWrittenText)
+			if (LineIdx != Lines.Num() - 1)
 			{
-				Segments.Add(FDialogueTextSegment{TEXT("\n")});
+				Segments.Emplace(
+					FDialogueTextSegment
+					{
+						TEXT("\n"),
+						FTextRunParseResults(FString(), FTextRange(0, 1))
+					});
 				++MaxLetterIndex;
 			}
-		}
 
-		Layout->SetWrappingWidth(0);
-		LineText->SetText(LineText->GetText());
-	}
-	else
-	{
-		Segments.Add(FDialogueTextSegment{CurrentLine.ToString()});
-		MaxLetterIndex = Segments[0].Text.Len();
+			MaxLetterIndex = Line.Range.EndIndex;
+		}
 	}
 }
 
 FString UDialogueBox::CalculateSegments()
 {
-	FString Result = CachedSegmentText;
-
-	int32 Idx = CachedLetterIndex;
-	while (Idx <= CurrentLetterIndex && CurrentSegmentIndex < Segments.Num())
+	while (CurrentSegmentIndex < Segments.Num())
 	{
 		const FDialogueTextSegment& Segment = Segments[CurrentSegmentIndex];
-		if (!Segment.RunInfo.Name.IsEmpty())
+
+		int32 SegmentStartIndex = std::max(Segment.RunInfo.OriginalRange.BeginIndex, Segment.RunInfo.ContentRange.BeginIndex);
+		CurrentLetterIndex = std::max(CurrentLetterIndex, SegmentStartIndex);
+
+		if (Segment.RunInfo.ContentRange.IsEmpty() ? !Segment.RunInfo.OriginalRange.Contains(CurrentLetterIndex) : !Segment.RunInfo.ContentRange.Contains(CurrentLetterIndex))
 		{
-			Result += FString::Printf(TEXT("<%s"), *Segment.RunInfo.Name);
-
-			if (!Segment.RunInfo.MetaData.IsEmpty())
-			{
-				for (const TTuple<FString, FString>& MetaData : Segment.RunInfo.MetaData)
-				{
-					Result += FString::Printf(TEXT(" %s=\"%s\""), *MetaData.Key, *MetaData.Value);
-				}
-			}
-
-			if (Segment.Text.IsEmpty())
-			{
-				Result += TEXT("/>");
-				++Idx; // This still takes up an index for the typewriter effect.
-			}
-			else
-			{
-				Result += TEXT(">");
-			}
+			CachedSegmentText += Segment.Text;
+			CurrentSegmentIndex++;
+			continue;
 		}
 
-		bool bIsSegmentComplete = true;
-		if (!Segment.Text.IsEmpty())
+		// is this segment an inline tag?
+		if (!Segment.RunInfo.Name.IsEmpty() && !Segment.RunInfo.MetaData.IsEmpty())
 		{
-			int32 LettersLeft = CurrentLetterIndex - Idx + 1;
-			bIsSegmentComplete = LettersLeft >= Segment.Text.Len();
-			LettersLeft = FMath::Min(LettersLeft, Segment.Text.Len());
-			Idx += LettersLeft;
+			// seek to end of tag - treat as single character
+			int32 SegmentEndIndex = std::max(Segment.RunInfo.OriginalRange.EndIndex, Segment.RunInfo.ContentRange.EndIndex);
+			CurrentLetterIndex = std::max(CurrentLetterIndex, SegmentEndIndex);
+			return CachedSegmentText + Segment.Text;
+		}
+		// is this segment partially typed?
+		else if (Segment.RunInfo.OriginalRange.Contains(CurrentLetterIndex))
+		{
+			FString Result = CachedSegmentText + Segment.Text.Mid(0, CurrentLetterIndex - Segment.RunInfo.OriginalRange.BeginIndex);
 
-			Result += Segment.Text.Mid(0, LettersLeft);
-
-			if (!Segment.RunInfo.Name.IsEmpty())
+			// if content tags need closing, append the remaining tag characters
+			if (!Segment.RunInfo.ContentRange.IsEmpty() && Segment.RunInfo.ContentRange.Contains(CurrentLetterIndex))
 			{
-				Result += TEXT("</>");
+				Result += Segment.Text.Mid(Segment.RunInfo.ContentRange.EndIndex - Segment.RunInfo.OriginalRange.BeginIndex, Segment.RunInfo.OriginalRange.EndIndex - Segment.RunInfo.ContentRange.EndIndex);
 			}
-		}
 
-		if (bIsSegmentComplete)
-		{
-			CachedLetterIndex = Idx;
-			CachedSegmentText = Result;
-			++CurrentSegmentIndex;
+			return Result;
 		}
-		else
-		{
-			break;
-		}
+		break;
 	}
 
-	return Result;
+	return CachedSegmentText;
 }

--- a/DialogueBox.cpp
+++ b/DialogueBox.cpp
@@ -3,7 +3,7 @@
 #include "DialogueBox.h"
 #include "Engine/Font.h"
 #include "Styling/SlateStyle.h"
-#include "Widgets/Text/SRichTextBlock.h"
+#include "SDialogueTextBlock.h"
 #include "TimerManager.h"
 
 #include <Framework/Text/SlateTextRun.h>
@@ -149,6 +149,23 @@ private:
 	const int32* CurrentSegmentIndex;
 };
 
+void UDialogueTextBlock::SetText(const FText& InText, const FText& InFinalText)
+{
+	if (SDialogueTextBlock* dialogueTextBlock = static_cast<SDialogueTextBlock*>(MyRichTextBlock.Get()))
+	{
+		dialogueTextBlock->SetText(dialogueTextBlock->MakeTextAttribute(InText, InFinalText));
+	}
+	else
+	{
+		Super::SetText(InText);
+	}
+}
+
+void UDialogueTextBlock::SetText(const FText& InText)
+{
+	Super::SetText(InText);
+}
+
 TSharedRef<SWidget> UDialogueTextBlock::RebuildWidget()
 {
 	// Copied from URichTextBlock::RebuildWidget
@@ -166,7 +183,7 @@ TSharedRef<SWidget> UDialogueTextBlock::RebuildWidget()
 	}
 
 	MyRichTextBlock =
-		SNew(SRichTextBlock)
+		SNew(SDialogueTextBlock)
 		.TextStyle(bOverrideDefaultStyle ? &DefaultTextStyleOverride : &DefaultTextStyle)
 		.Marshaller(Marshaller);
 
@@ -197,7 +214,7 @@ void UDialogueBox::PlayLine(const FText& InLine)
 	{
 		if (IsValid(LineText))
 		{
-			LineText->SetText(FText::GetEmpty());
+			LineText->SetText(FText::GetEmpty(), FText::GetEmpty());
 		}
 
 		bHasFinishedPlaying = true;
@@ -209,7 +226,7 @@ void UDialogueBox::PlayLine(const FText& InLine)
 	{
 		if (IsValid(LineText))
 		{
-			LineText->SetText(FText::GetEmpty());
+			LineText->SetText(FText::GetEmpty(), CurrentLine);
 		}
 
 		bHasFinishedPlaying = false;
@@ -231,7 +248,7 @@ void UDialogueBox::SkipToLineEnd()
 	CurrentLetterIndex = MaxLetterIndex - 1;
 	if (IsValid(LineText))
 	{
-		LineText->SetText(FText::FromString(CalculateSegments()));
+		LineText->SetText(FText::FromString(CalculateSegments()), CurrentLine);
 	}
 
 	bHasFinishedPlaying = true;
@@ -259,7 +276,7 @@ void UDialogueBox::PlayNextLetter()
 	{
 		if (IsValid(LineText))
 		{
-			LineText->SetText(FText::FromString(WrappedString));
+			LineText->SetText(FText::FromString(WrappedString), CurrentLine);
 		}
 
 		OnPlayLetter();
@@ -269,7 +286,7 @@ void UDialogueBox::PlayNextLetter()
 	{
 		if (IsValid(LineText))
 		{
-			LineText->SetText(FText::FromString(CalculateSegments()));
+			LineText->SetText(FText::FromString(CalculateSegments()), CurrentLine);
 		}
 
 		FTimerManager& TimerManager = GetWorld()->GetTimerManager();

--- a/DialogueBox.h
+++ b/DialogueBox.h
@@ -43,7 +43,7 @@ struct FDialogueTextSegment
 };
 
 UCLASS()
-class FLAME_API UDialogueBox : public UUserWidget
+class UDialogueBox : public UUserWidget
 {
 	GENERATED_BODY()
 

--- a/DialogueBox.h
+++ b/DialogueBox.h
@@ -9,6 +9,8 @@
 #include "Framework/Text/SlateTextLayout.h"
 #include "DialogueBox.generated.h"
 
+struct FDialogueTextSegment;
+
 /**
  * A text block that exposes more information about text layout.
  */
@@ -18,28 +20,31 @@ class UDialogueTextBlock : public URichTextBlock
 	GENERATED_BODY()
 
 public:
-	FORCEINLINE TSharedPtr<FSlateTextLayout> GetTextLayout() const
+	FORCEINLINE TSharedPtr<IRichTextMarkupParser> GetTextParser() const
 	{
-		return TextLayout;
+		return TextParser;
 	}
 
-	FORCEINLINE TSharedPtr<FRichTextLayoutMarshaller> GetTextMarshaller() const
+	FORCEINLINE void ConfigureFromParent(const TArray<FDialogueTextSegment>* InSegments, const int32* InCurrentSegmentIndex)
 	{
-		return TextMarshaller;
+		Segments = InSegments;
+		CurrentSegmentIndex = InCurrentSegmentIndex;
 	}
 
 protected:
 	virtual TSharedRef<SWidget> RebuildWidget() override;
 
 private:
-	TSharedPtr<FSlateTextLayout> TextLayout;
-	TSharedPtr<FRichTextLayoutMarshaller> TextMarshaller;
+	TSharedPtr<IRichTextMarkupParser> TextParser;
+
+	const TArray<FDialogueTextSegment>* Segments;
+	const int32* CurrentSegmentIndex;
 };
 
 struct FDialogueTextSegment
 {
 	FString Text;
-	FRunInfo RunInfo;
+	FTextRunParseResults RunInfo;
 };
 
 UCLASS()
@@ -81,6 +86,8 @@ protected:
 	UFUNCTION(BlueprintImplementableEvent, Category = "Dialogue Box")
 	void OnLineFinishedPlaying();
 
+	void NativeOnInitialized() override;
+
 private:
 	void PlayNextLetter();
 
@@ -97,7 +104,6 @@ private:
 	// everything as the last few characters of a string may change if they're related to
 	// a named run that hasn't been completed yet.
 	FString CachedSegmentText;
-	int32 CachedLetterIndex = 0;
 
 	int32 CurrentSegmentIndex = 0;
 	int32 CurrentLetterIndex = 0;

--- a/DialogueBox.h
+++ b/DialogueBox.h
@@ -31,7 +31,13 @@ public:
 		CurrentSegmentIndex = InCurrentSegmentIndex;
 	}
 
+	// variant method to feed slate widget more info
+	void SetText(const FText& InText, const FText& InFinalText);
+
 protected:
+	// implementation hidden in favour of two parameter variant
+	void SetText(const FText& InText) override;
+
 	virtual TSharedRef<SWidget> RebuildWidget() override;
 
 private:

--- a/DialogueBox.h
+++ b/DialogueBox.h
@@ -31,12 +31,16 @@ public:
 		CurrentSegmentIndex = InCurrentSegmentIndex;
 	}
 
-	// variant method to feed slate widget more info
-	void SetText(const FText& InText, const FText& InFinalText);
+	// variants to feed slate widget more info
+	void SetTextPartiallyTyped(const FText& InText, const FText& InFinalText);
+	void SetTextFullyTyped(const FText& InText);
 
 protected:
-	// implementation hidden in favour of two parameter variant
-	void SetText(const FText& InText) override;
+	// implementation hidden in favour of explicit variants
+	void SetText(const FText& InText) override
+	{
+		URichTextBlock::SetText(InText);
+	}
 
 	virtual TSharedRef<SWidget> RebuildWidget() override;
 

--- a/README.md
+++ b/README.md
@@ -16,10 +16,8 @@ you want.
 * Changing font-size (or using a decorator that's taller than the existing text) anywhere except at the beginning of a line will result in
   the entire line "jumping" down slightly to accomodate the new text size. I don't have a solution to this yet and don't see myself using
   different font sizes much, so it isn't something I'm likely to get to any time soon.
-* Text wrapping is only calculated a single time when the first character is played. If the widget is resized for any reason, text will
-  not respect the new boundaries. This should be simple to solve, I just haven't done it yet.
 * There may be some hidden i18n issues due to all the conversions between `FString`/`FText` and string indexing.
-* This has been tested with UE5.0EA, though it should work fine with earlier/later versions.
+* This has been tested with UE 5.2.0, though it should work fine with earlier/later versions.
 * The current implementation was quickly thrown together (see: hacky) and somewhat unoptimized. Some data is duplicated more than it needs
   to be, and "segment" calculation is a bit more complex than I'd like.
 

--- a/SDialogueTextBlock.cpp
+++ b/SDialogueTextBlock.cpp
@@ -1,0 +1,32 @@
+#include "SDialogueTextBlock.h"
+
+TAttribute<FText> SDialogueTextBlock::MakeTextAttribute(const FText& typedText, const FText& finalText) const
+{
+	return TAttribute<FText>::CreateRaw(this, &SDialogueTextBlock::GetTextInternal, typedText, finalText);
+}
+
+FVector2D SDialogueTextBlock::ComputeDesiredSize(float LayoutScaleMultiplier) const
+{
+	// calculate actual maxmimum dialogue size
+	isComputingDesiredSize = true;
+	auto result = SRichTextBlock::ComputeDesiredSize(LayoutScaleMultiplier);
+	isComputingDesiredSize = false;
+
+	// poke the method again because this internally caches some junk pertaining to layout/content
+	(void)SRichTextBlock::ComputeDesiredSize(LayoutScaleMultiplier);
+
+	// return the overridden value
+	return result;
+}
+
+FText SDialogueTextBlock::GetTextInternal(FText typedText, FText finalText) const
+{
+	if (isComputingDesiredSize)
+	{
+		return finalText;
+	}
+	else
+	{
+		return typedText;
+	}
+}

--- a/SDialogueTextBlock.cpp
+++ b/SDialogueTextBlock.cpp
@@ -7,16 +7,20 @@ TAttribute<FText> SDialogueTextBlock::MakeTextAttribute(const FText& typedText, 
 
 FVector2D SDialogueTextBlock::ComputeDesiredSize(float LayoutScaleMultiplier) const
 {
+	return m_cachedDesiredSize;
+}
+
+void SDialogueTextBlock::CacheDesiredSize(float LayoutScaleMultiplier)
+{
 	// calculate actual maxmimum dialogue size
 	isComputingDesiredSize = true;
-	auto result = SRichTextBlock::ComputeDesiredSize(LayoutScaleMultiplier);
+	m_cachedDesiredSize = SRichTextBlock::ComputeDesiredSize(LayoutScaleMultiplier);
 	isComputingDesiredSize = false;
 
 	// poke the method again because this internally caches some junk pertaining to layout/content
 	(void)SRichTextBlock::ComputeDesiredSize(LayoutScaleMultiplier);
 
-	// return the overridden value
-	return result;
+	SRichTextBlock::CacheDesiredSize(LayoutScaleMultiplier);
 }
 
 FText SDialogueTextBlock::GetTextInternal(FText typedText, FText finalText) const

--- a/SDialogueTextBlock.h
+++ b/SDialogueTextBlock.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <Widgets/Text/SRichTextBlock.h>
+
+class SDialogueTextBlock : public SRichTextBlock
+{
+public:
+	TAttribute<FText> MakeTextAttribute(const FText& typedText, const FText& finalText) const;
+
+protected:
+	FVector2D ComputeDesiredSize(float LayoutScaleMultiplier) const override;
+
+private:
+	FText GetTextInternal(FText typedText, FText finalText) const;
+
+	mutable bool isComputingDesiredSize;
+};

--- a/SDialogueTextBlock.h
+++ b/SDialogueTextBlock.h
@@ -8,10 +8,12 @@ public:
 	TAttribute<FText> MakeTextAttribute(const FText& typedText, const FText& finalText) const;
 
 protected:
+	void CacheDesiredSize(float LayoutScaleMultiplier) override;
 	FVector2D ComputeDesiredSize(float LayoutScaleMultiplier) const override;
 
 private:
 	FText GetTextInternal(FText typedText, FText finalText) const;
 
 	mutable bool isComputingDesiredSize;
+	FVector2D m_cachedDesiredSize;
 };


### PR DESCRIPTION
My use-case for this code needed to support dynamically-sized layouts, so after some research settled on this alternate implementation. You are welcome to disregard this pull request as it's quite a divergence from the original implementation, but if you wouldn't mind reviewing briefly and letting me know if I'm in the weeds on this I'd appreciate it! I'm fairly new to UE, so I may have committed some grave error here I'm not otherwise aware of.



My initial attempt at allowing for a dynamic widget transform was to duplicate the implementation of URichTextBlock/SRichTextBlock and signal back to the parent when new geometry is calculated. I wasn't happy with this approach because it:
- Duplicated hundreds of lines of engine code whereas I just wanted to modify a few private/non-virtual methods.
- Duplicated a lot of work that the engine was doing automatically when text was added to the layout.
- Broke compatibility with various existing Rich Text tools (custom decorators/etc would be incompatible.
... so I ditched that implementation.

This new approach uses a custom decorator to intercept the segment which is currently being "typed out". Once this segment is identified, a custom text run overrides the Measure() method to return full size of the block in order to force the correct line break to be generated. Because this approach is layout-agnostic, the widget's transform can be modified freely without needing to re-calculate line breaks.

Additionally, I believe this new implementation fixes the issue you were having with image/custom decorators behaving strangely - they will have their sizes calculated dynamically per-layout so anything crazy they do should automatically inform the rest of the layout without intervention.

Either way thank you for your original implementation, I have learnt a lot from it :)